### PR TITLE
Add new cognito client module allowing for named clients

### DIFF
--- a/named-cognito-client/main.tf
+++ b/named-cognito-client/main.tf
@@ -1,0 +1,79 @@
+data "aws_region" "current" {}
+
+data "aws_caller_identity" "current" {}
+
+locals {
+  current_account_id = data.aws_caller_identity.current.account_id
+  current_region     = data.aws_region.current.name
+}
+
+###########################################################
+# Create App Client in the central Cognito for frontend login
+#
+# Intended to be used from the backend for frontend application
+###########################################################
+
+# upload delegated cognito config to S3 bucket.
+# this will trigger the delegated cognito terraform pipeline and and apply the config.
+resource "aws_s3_bucket_object" "delegated-cognito-config" {
+  count  = var.create_resource_server ? 1 : 0
+  bucket = var.cognito_central_bucket
+  key    = "${length(var.cognito_central_override_env) > 0 ? var.cognito_central_override_env : var.environment}/${local.current_account_id}/${var.name_prefix}-${var.application_name}-${var.app_client_name}.json"
+  acl    = "bucket-owner-full-control"
+
+  content = jsonencode({
+    # Configure a user pool client
+    user_pool_client = {
+      name_prefix     = "${var.name_prefix}-${var.application_name}-${var.app_client_name}"
+      generate_secret = false
+
+      allowed_oauth_flows                  = var.app_oauth_flows
+      allowed_oauth_scopes                 = var.app_oauth_scopes
+      allowed_oauth_flows_user_pool_client = true
+      supported_identity_providers         = var.supported_identity_providers
+      callback_urls                        = var.callback_urls
+      logout_urls                          = var.logout_urls
+    }
+  })
+  content_type = "application/json"
+}
+
+
+##
+# Read Credentials from Secrets Manager and set in microservice SSM config.
+# Store the md5 of the cognito config so that a change in md5/config
+# Will trigger a new update on dependent resources.
+#
+# Using workaround using time_sleep for async pipeline in cognito to complete
+# configuration of resource server and application client in delegated cognito.
+# The sleep wait will only occur when the dependent S3 file is updated
+# and during normal operation without changes it will not pause here.
+resource "time_sleep" "wait_for_credentials" {
+  count           = var.create_app_client ? 1 : 0
+  create_duration = "300s"
+
+  triggers = {
+    config_hash = sha1(aws_s3_bucket_object.delegated-cognito-config[0].content)
+  }
+}
+
+# The client credentials that are stored in Central Cognito.
+data "aws_secretsmanager_secret_version" "microservice_client_credentials" {
+  depends_on = [aws_s3_bucket_object.delegated-cognito-config[0], time_sleep.wait_for_credentials[0]]
+  count      = var.create_app_client ? 1 : 0
+  secret_id  = "arn:aws:secretsmanager:eu-west-1:${var.cognito_central_account_id}:secret:${local.current_account_id}-${var.name_prefix}-${var.application_name}-${var.app_client_name}-id"
+}
+
+# Store client credentials from Central Cognito in SSM so that the application can read it.
+resource "aws_ssm_parameter" "central_client_id" {
+  name      = "/${var.name_prefix}/config/${var.application_name}/cognito.${var.app_client_name}-clientId"
+  type      = "SecureString"
+  value     = jsondecode(data.aws_secretsmanager_secret_version.microservice_client_credentials[0].secret_string)["client_id"]
+  overwrite = true
+
+  # store the hash as a tag to establish a dependency to the wait_for_credentials resource
+  tags = merge(var.tags, {
+    config_hash : time_sleep.wait_for_credentials[0].triggers.config_hash
+  })
+}
+

--- a/named-cognito-client/main.tf
+++ b/named-cognito-client/main.tf
@@ -15,8 +15,7 @@ locals {
 
 # upload delegated cognito config to S3 bucket.
 # this will trigger the delegated cognito terraform pipeline and and apply the config.
-resource "aws_s3_bucket_object" "delegated-cognito-config" {
-  count  = var.create_resource_server ? 1 : 0
+resource "aws_s3_bucket_object" "delegated-cognito-config" {  
   bucket = var.cognito_central_bucket
   key    = "${length(var.cognito_central_override_env) > 0 ? var.cognito_central_override_env : var.environment}/${local.current_account_id}/${var.name_prefix}-${var.application_name}-${var.app_client_name}.json"
   acl    = "bucket-owner-full-control"
@@ -48,8 +47,7 @@ resource "aws_s3_bucket_object" "delegated-cognito-config" {
 # configuration of resource server and application client in delegated cognito.
 # The sleep wait will only occur when the dependent S3 file is updated
 # and during normal operation without changes it will not pause here.
-resource "time_sleep" "wait_for_credentials" {
-  count           = var.create_app_client ? 1 : 0
+resource "time_sleep" "wait_for_credentials" {  
   create_duration = "300s"
 
   triggers = {

--- a/named-cognito-client/variables.tf
+++ b/named-cognito-client/variables.tf
@@ -62,14 +62,3 @@ variable "logout_urls" {
 variable "tags" {
   type = map(string)
 }
-
-variable "create_resource_server" {
-  description = "Create resource server in Cognito for microservice."
-  default     = false
-  type        = bool
-}
-
-variable "create_app_client" {
-  description = "Create application client in Cognito for microservice."
-  type        = bool
-}

--- a/named-cognito-client/variables.tf
+++ b/named-cognito-client/variables.tf
@@ -1,0 +1,75 @@
+variable "name_prefix" {
+  description = "A prefix used for naming resources."
+}
+
+variable "application_name" {
+  description = "Name of the application."
+}
+
+variable "app_client_name" {
+  description = "Name of the app client, used to differ between multiple clients"
+}
+
+variable "environment" {
+  description = "Name of the environment, Ex. dev, test ,stage, prod."
+  type        = string
+}
+
+
+variable "app_oauth_scopes" {
+  description = "List of allowed OAuth scopes (phone, email, openid, profile, and aws.cognito.signin.user.admin)."
+  type        = list(string)
+}
+
+variable "app_oauth_flows" {
+  description = "List of allowed OAuth flows (code, implicit, client_credentials)."
+  type        = list(string)
+}
+
+variable "cognito_central_bucket" {
+  description = "(Optional) Configure where to upload delegated cognito config. Default is vydev-delegated-cognito-staging."
+  type        = string
+  default     = "vydev-delegated-cognito-staging"
+}
+
+variable "cognito_central_override_env" {
+  description = " Override which env to upload to for delegated cognito, default is the \"environment\"-variable."
+  type        = string
+  default     = ""
+}
+
+variable "cognito_central_account_id" {
+  description = "Set cognito account id from where to read the Client ID and Client Secret from."
+  type        = string
+}
+
+variable "supported_identity_providers" {
+  description = "List of provider names for the identity providers that are supported on this client."
+  type        = list(string)
+}
+
+variable "callback_urls" {
+  description = "List of allowed callback URLs for the identity provider"
+  type        = list(string)
+}
+
+variable "logout_urls" {
+  description = "List of allowed logout URLs for the identity provider"
+  type        = list(string)
+}
+
+
+variable "tags" {
+  type = map(string)
+}
+
+variable "create_resource_server" {
+  description = "Create resource server in Cognito for microservice."
+  default     = false
+  type        = bool
+}
+
+variable "create_app_client" {
+  description = "Create application client in Cognito for microservice."
+  type        = bool
+}

--- a/named-cognito-client/versions.tf
+++ b/named-cognito-client/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">=0.12.24"
+  required_version = ">=1.0.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.21.0"
+      version = ">=3.63.0"
     }
   }
 }

--- a/named-cognito-client/versions.tf
+++ b/named-cognito-client/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">=0.12.24"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.21.0"
+    }
+  }
+}


### PR DESCRIPTION
Jeg har lagt til en modul der man kan navngi app klientene for å kunne opprette flere klienter i samme terraform. Dette skal brukes til å kunne servere frontender med klientIder fra backend.