### PR TITLE
update ssm parameter path

### DIFF
--- a/named-cognito-client/main.tf
+++ b/named-cognito-client/main.tf
@@ -63,7 +63,7 @@ data "aws_secretsmanager_secret_version" "microservice_client_credentials" {
 
 # Store client credentials from Central Cognito in SSM so that the application can read it.
 resource "aws_ssm_parameter" "central_client_id" {
-  name      = "/${var.application_name}/config/application/cognito.${var.app_client_name}-clientId"
+  name      = "/${var.name_prefix}/config/${var.application_name}/cognito.${var.app_client_name}-clientId"
   type      = "SecureString"
   value     = jsondecode(data.aws_secretsmanager_secret_version.microservice_client_credentials.secret_string)["client_id"]
   overwrite = true


### PR DESCRIPTION
### 🧐 Hva skjer? 
Har endret url for central_client_id ssm parameter i named-cognito-client, slik at den matcher med url'en de andre teamene bruker i sine moduler. Da slipper vi å ha kopier av alle ssm parametrene som opprettes automatisk via deres moduler. 